### PR TITLE
change name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel dependencies"
 
 module(
-    name = "com_bookingcom_rules_pitest",
+    name = "rules_pitest",
     version = "0.0.0",
     compatibility_level = 1,
 )

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -34,7 +34,7 @@ pitest directly. The arguments are the same as used by `java_test`.
 | <a id="java_pitest_test-test_targets"></a>test_targets |  bazel test targets that are used by pitest   |  <code>[]</code> |
 | <a id="java_pitest_test-library_targets"></a>library_targets |  bazel libraries that are going to be mutated by pitest   |  <code>[]</code> |
 | <a id="java_pitest_test-target_classes"></a>target_classes |  pitest targetClasses cli argument   |  <code>[]</code> |
-| <a id="java_pitest_test-rules_pitest"></a>rules_pitest |  Alias for the rules_pitest in case you don't import as com_bookingcom_rules_pitest   |  <code>"com_bookingcom_rules_pitest"</code> |
+| <a id="java_pitest_test-rules_pitest"></a>rules_pitest |  Alias for the rules_pitest in case you don't import as rules_pitest   |  <code>"rules_pitest"</code> |
 | <a id="java_pitest_test-kwargs"></a>kwargs |  Aditional flags to the test   |  none |
 
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,5 +1,4 @@
 bazel_dep(name = "rules_pitest", version = "0.0.0")
-
 local_path_override(
     module_name = "rules_pitest",
     path = "../..",
@@ -10,7 +9,6 @@ bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "contrib_rules_jvm", version = "0.24.0")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
-
 maven.install(
     name = "maven",
     artifacts = [
@@ -29,7 +27,6 @@ maven.install(
     fetch_sources = True,
     lock_file = "//:maven_install.json",
 )
-
 use_repo(
     maven,
     "maven",

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,6 +1,7 @@
-bazel_dep(name = "com_bookingcom_rules_pitest", version = "0.0.0")
+bazel_dep(name = "rules_pitest", version = "0.0.0")
+
 local_path_override(
-    module_name = "com_bookingcom_rules_pitest",
+    module_name = "rules_pitest",
     path = "../..",
 )
 
@@ -9,6 +10,7 @@ bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "contrib_rules_jvm", version = "0.24.0")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
 maven.install(
     name = "maven",
     artifacts = [
@@ -27,6 +29,7 @@ maven.install(
     fetch_sources = True,
     lock_file = "//:maven_install.json",
 )
+
 use_repo(
     maven,
     "maven",

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -1,6 +1,6 @@
 # Override http_archive for local testing
 local_repository(
-    name = "com_bookingcom_rules_pitest",
+    name = "rules_pitest",
     path = "../..",
 )
 
@@ -14,7 +14,7 @@ local_repository(
 # you should fetch it *before* calling this.
 # Alternatively, you can skip calling this function, so long as you've
 # already fetched all the dependencies.
-load("@com_bookingcom_rules_pitest//pitest:repositories.bzl", "rules_pitest_dependencies")
+load("@rules_pitest//pitest:repositories.bzl", "rules_pitest_dependencies")
 
 rules_pitest_dependencies()
 
@@ -40,7 +40,7 @@ load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
 
 rules_jvm_external_setup()
 
-load("@com_bookingcom_rules_pitest//pitest:deps.bzl", pitest_maven_dependencies = "maven_dependencies")
+load("@rules_pitest//pitest:deps.bzl", pitest_maven_dependencies = "maven_dependencies")
 
 pitest_maven_dependencies()
 

--- a/e2e/smoke/sample-from-upstream/BUILD.bazel
+++ b/e2e/smoke/sample-from-upstream/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_bookingcom_rules_pitest//pitest:defs.bzl", "java_pitest_test")
+load("@rules_pitest//pitest:defs.bzl", "java_pitest_test")
 load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
 load("@rules_java//java:defs.bzl", "java_library")
 
@@ -104,10 +104,10 @@ java_pitest_test(
     ],
     runtime_deps = [
         "//test-helpers",
-        "@com_bookingcom_rules_pitest//pitest:org_pitest_pitest_junit5_plugin",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
         "@maven//:org_junit_jupiter_junit_jupiter_engine",
         "@maven//:org_junit_platform_junit_platform_launcher",
         "@maven//:org_junit_platform_junit_platform_reporting",
+        "@rules_pitest//pitest:org_pitest_pitest_junit5_plugin",
     ],
 )

--- a/e2e/smoke/sample-from-upstream/BUILD.bazel
+++ b/e2e/smoke/sample-from-upstream/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_pitest//pitest:defs.bzl", "java_pitest_test")
 load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
 load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_pitest//pitest:defs.bzl", "java_pitest_test")
 
 # gazelle:java_module_granularity module
 # gazelle:java_test_mode file

--- a/pitest/BUILD.bazel
+++ b/pitest/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_java//java:defs.bzl", "java_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 # For stardoc to reference the files
 exports_files(["defs.bzl"])

--- a/pitest/private/rules.bzl
+++ b/pitest/private/rules.bzl
@@ -79,7 +79,7 @@ def java_pitest_test(
         test_targets = [],
         library_targets = [],
         target_classes = [],
-        rules_pitest = "com_bookingcom_rules_pitest",
+        rules_pitest = "rules_pitest",
         **kwargs):
     """Runs pitest test using Bazel.
 
@@ -101,7 +101,7 @@ def java_pitest_test(
         library_targets: bazel libraries that are going to be mutated by pitest
         target_classes: pitest targetClasses cli argument
         package_prefixes: List of prefixes for your maven targets
-        rules_pitest: Alias for the rules_pitest in case you don't import as com_bookingcom_rules_pitest
+        rules_pitest: Alias for the rules_pitest in case you don't import as rules_pitest
         **kwargs: Aditional flags to the test
 
     """


### PR DESCRIPTION
Change name to avoid error when loading the module with bzlmod:
```
ERROR: Error computing the main repository mapping: in module dependency chain <root> -> rules_pitest@0.0.0: the MODULE.bazel file of rules_pitest@0.0.0 declares a different name (com_bookingcom_rules_pitest)
```